### PR TITLE
Defining PUBLIC_METHODS whitelist for all WebServices

### DIFF
--- a/lib/WebService/Backlog.pm
+++ b/lib/WebService/Backlog.pm
@@ -40,6 +40,11 @@ use constant FIELD_TYPES => {
     team_id => "int",
 };
 
+use constant PUBLIC_METHODS => qw(
+    update
+    create
+);
+
 =head1 METHODS
 
 =over

--- a/lib/WebService/Pool.pm
+++ b/lib/WebService/Pool.pm
@@ -48,6 +48,12 @@ use constant FIELD_TYPES => {
     "name" => "string",
 };
 
+use constant PUBLIC_METHODS => qw(
+    get
+    add_bug
+    remove_bug
+);
+
 =head1 METHODS
 
 =over

--- a/lib/WebService/Sprint.pm
+++ b/lib/WebService/Sprint.pm
@@ -43,6 +43,16 @@ use constant FIELD_TYPES => {
     "committed" => "boolean",
 };
 
+use constant PUBLIC_METHODS => qw(
+    get
+    create
+    update
+    close
+    commit
+    uncommit
+    delete
+);
+
 =head1 METHODS
 
 =over

--- a/lib/WebService/Team.pm
+++ b/lib/WebService/Team.pm
@@ -50,6 +50,15 @@ use constant FIELD_TYPES => {
     process_id => "int",
 };
 
+use constant PUBLIC_METHODS => qw(
+    update
+    add_member
+    remove_member
+    add_member_role
+    remove_member_role
+    unprioritized_items
+);
+
 =head1 METHODS
 
 =over

--- a/lib/WebService/Util.pm
+++ b/lib/WebService/Util.pm
@@ -43,6 +43,11 @@ package Bugzilla::Extension::AgileTools::WebService::Util;
 use strict;
 use warnings;
 
+use constant PUBLIC_METHODS => qw(
+    object_to_hash
+    changes_to_hash
+);
+
 use base qw(Exporter);
 our @EXPORT = qw(
     object_to_hash


### PR DESCRIPTION
Since Mozilla fixed Bugzilla bug 1090275 (https://bugzilla.mozilla.org/show_bug.cgi?id=1090275) any WebService methods need to be declared as public, otherwise they are blocked from being accessed.  This is a security feature, but it breaks a lot of extensions.

This commit updates the AgileTools WebService scripts to define their white-lists appropriately.

I have assumed that all methods are public - if that is not the case then the white list will need to be updated to remove whatever should not be there.

This fixes #17.